### PR TITLE
Bring tutorial code snippets in-sync with latest source #6077

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix undefined names: docstr and VisibleDeprecationWarning (PR #3844)
 * Corrected documentation for Tensor based PointClound, LineSet, TriangleMesh (PR #4685)
 * Corrected documentation for KDTree (typo in Notebook) (PR #4744)
+* Corrected documentation for visualisation tutorial
 * Remove `setuptools` and `wheel` from requirements for end users (PR #5020)
 * Fix various typos (PR #5070)
 * Exposed more functionality in SLAM and odometry pipelines

--- a/docs/tutorial/visualization/customized_visualization.rst
+++ b/docs/tutorial/visualization/customized_visualization.rst
@@ -12,8 +12,8 @@ Mimic draw_geometries() with Visualizer class
 
 .. literalinclude:: ../../../examples/python/visualization/customized_visualization.py
    :language: python
-   :lineno-start: 37
-   :lines: 37-44
+   :lineno-start: 39
+   :lines: 39-47
    :linenos:
 
 This function produces exactly the same functionality as the convenience function ``draw_geometries``.
@@ -25,8 +25,8 @@ Class ``Visualizer`` has a couple of variables such as a ``ViewControl`` and a `
 
 .. literalinclude:: ../../../examples/python/visualization/customized_visualization.py
    :language: python
-   :lineno-start: 70
-   :lines: 70-76
+   :lineno-start: 50
+   :lines: 50-56
    :linenos:
 
 Outputs:
@@ -40,8 +40,8 @@ To change field of view of the camera, it is first necessary to get an instance 
 
 .. literalinclude:: ../../../examples/python/visualization/customized_visualization.py
    :language: python
-   :lineno-start: 47
-   :lines: 47-56
+   :lineno-start: 27
+   :lines: 27-36
    :linenos:
 
 The field of view (FoV) can be set to a degree in the range [5,90]. Note that ``change_field_of_view`` adds the specified FoV to the current FoV. By default, the visualizer has an FoV of 60 degrees. Calling the following code
@@ -71,8 +71,8 @@ Callback functions
 
 .. literalinclude:: ../../../examples/python/visualization/customized_visualization.py
    :language: python
-   :lineno-start: 59
-   :lines: 59-67
+   :lineno-start: 39
+   :lines: 39-47
    :linenos:
 
 Function ``draw_geometries_with_animation_callback`` registers a Python callback function ``rotate_view`` as the idle function of the main loop. It rotates the view along the x-axis whenever the visualizer is idle. This defines an animation behavior.
@@ -82,8 +82,8 @@ Function ``draw_geometries_with_animation_callback`` registers a Python callback
 
 .. literalinclude:: ../../../examples/python/visualization/customized_visualization.py
    :language: python
-   :lineno-start: 79
-   :lines: 79-108
+   :lineno-start: 59
+   :lines: 59-87
    :linenos:
 
 Callback functions can also be registered upon key press event. This script registered four keys. For example, pressing :kbd:`k` changes the background color to black.
@@ -96,8 +96,8 @@ Capture images in a customized animation
 
 .. literalinclude:: ../../../examples/python/visualization/customized_visualization.py
    :language: python
-   :lineno-start: 109
-   :lines: 111-162
+   :lineno-start: 90
+   :lines: 90-141
    :linenos:
 
 This function reads a camera trajectory, then defines an animation function ``move_forward`` to travel through the camera trajectory. In this animation function, both color image and depth image are captured using ``Visualizer.capture_depth_float_buffer`` and ``Visualizer.capture_screen_float_buffer`` respectively. The images are saved as png files.


### PR DESCRIPTION
Fixes the start and end point of code snippets in the identified documentation

## Type

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6077

## Motivation and Context

The current code snippets are displayed incorrectly

## Checklist:

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

This PR brings tutorial code snippets back in-sync with latest source.  